### PR TITLE
RLS -> rust-analyzer in devcontainer.

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -19,7 +19,7 @@
 	},
 	// Add the IDs of extensions you want installed when the container is created.
 	"extensions": [
-		"rust-lang.rust",
+		"matklad.rust-analyzer",
 		"bungcip.better-toml",
 		"vadimcn.vscode-lldb",
 		// (Optional) Displays the current CPU stats, memory/disk consumption, clock freq. etc. of the container host in the VS Code status bar.


### PR DESCRIPTION
# Introduction
Per the new rust recommendations, this PR switches the vscode devcontainer to use the `matklad.rust-analyzer` extension instead of the `rust-lang.rls` language server.

# Linked Issues
resolves #8 
# Dependencies

# Test
- [x] Tested Locally
- [ ] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
