### PR TITLE
Command dispatcher

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,6 +74,7 @@ pub struct Cmd {
     description: String,
     version: String,
     flags: Vec<Flag>,
+    subcommands: Vec<Cmd>,
     handler_func: Box<DispatchFn>,
 }
 
@@ -112,7 +113,13 @@ impl Cmd {
         self
     }
 
-    /// Set a flag.
+    /// Set a subcommand.
+    pub fn subcommand(mut self, c: Cmd) -> Cmd {
+        self.subcommands.push(c);
+        self
+    }
+
+    /// Set a cmd handler.
     pub fn handler(mut self, handler: Box<DispatchFn>) -> Cmd {
         self.handler_func = handler;
         self
@@ -144,6 +151,7 @@ impl default::Default for Cmd {
             description: String::new(),
             version: String::new(),
             flags: Vec::new(),
+            subcommands: Vec::new(),
             handler_func: Box::new(|_conf| Err("Unimplemented".to_string())),
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,7 +66,7 @@ impl PartialEq for CmdDispatcher {
     }
 }
 
-/// Cmd functions as the top level wrapper for a command command line tool
+/// Cmd functions as the top level wrapper for a command line tool
 /// storing information about the tool, author, version and a brief description.
 pub struct Cmd {
     name: String,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,7 +74,6 @@ pub struct Cmd {
     description: String,
     version: String,
     flags: Vec<Flag>,
-    subcommands: Vec<Cmd>,
     handler_func: Box<DispatchFn>,
 }
 
@@ -113,12 +112,6 @@ impl Cmd {
         self
     }
 
-    /// Set a subcommand.
-    pub fn subcommand(mut self, c: Cmd) -> Cmd {
-        self.subcommands.push(c);
-        self
-    }
-
     /// Set a cmd handler.
     pub fn handler(mut self, handler: Box<DispatchFn>) -> Cmd {
         self.handler_func = handler;
@@ -151,7 +144,6 @@ impl default::Default for Cmd {
             description: String::new(),
             version: String::new(),
             flags: Vec::new(),
-            subcommands: Vec::new(),
             handler_func: Box::new(|_conf| Err("Unimplemented".to_string())),
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,7 @@ pub struct Cmd {
     description: String,
     version: String,
     flags: Vec<Flag>,
+    handler: Box<DispatchFn>,
 }
 
 impl Cmd {
@@ -65,6 +66,12 @@ impl Cmd {
         self.flags.push(f);
         self
     }
+
+    /// Set a flag.
+    pub fn handler(mut self, handler: Box<DispatchFn>) -> Cmd {
+        self.handler = handler;
+        self
+    }
 }
 
 impl fmt::Display for Cmd {
@@ -92,6 +99,7 @@ impl default::Default for Cmd {
             description: String::new(),
             version: String::new(),
             flags: Vec::new(),
+            handler: Box::new(|_conf| {}),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,11 +15,14 @@ mod parsers;
 #[cfg(test)]
 mod tests;
 
+/// Config represents a String -> Value mapping as parsed from flags.
 pub type Config = HashMap<String, Value>;
+
+/// DispatchFn stores an invocable function to be called by the cli
+pub type DispatchFn = dyn FnOnce(Config);
 
 /// Cmd functions as the top level wrapper for a command command line tool
 /// storing information about the tool, author, version and a brief description.
-#[derive(Debug, Clone, PartialEq)]
 pub struct Cmd {
     name: String,
     author: String,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,10 +17,10 @@ mod tests;
 
 pub type Config = HashMap<String, Value>;
 
-/// App functions as the top level wrapper for a command command line tool
+/// Cmd functions as the top level wrapper for a command command line tool
 /// storing information about the tool, author, version and a brief description.
 #[derive(Debug, Clone, PartialEq)]
-pub struct App {
+pub struct Cmd {
     name: String,
     author: String,
     description: String,
@@ -28,43 +28,43 @@ pub struct App {
     flags: Vec<Flag>,
 }
 
-impl App {
+impl Cmd {
     pub fn new() -> Self {
         Self::default()
     }
 
     /// Set the command name.
-    pub fn name(mut self, name: &str) -> App {
+    pub fn name(mut self, name: &str) -> Cmd {
         self.name = name.to_string();
         self
     }
 
     /// Set the author name.
-    pub fn author(mut self, author: &str) -> App {
+    pub fn author(mut self, author: &str) -> Cmd {
         self.author = author.to_string();
         self
     }
 
     /// Set the short description.
-    pub fn description(mut self, desc: &str) -> App {
+    pub fn description(mut self, desc: &str) -> Cmd {
         self.description = desc.to_string();
         self
     }
 
     /// Set the version.
-    pub fn version(mut self, vers: &str) -> App {
+    pub fn version(mut self, vers: &str) -> Cmd {
         self.version = vers.to_string();
         self
     }
 
     /// Set a flag.
-    pub fn flag(mut self, f: Flag) -> App {
+    pub fn flag(mut self, f: Flag) -> Cmd {
         self.flags.push(f);
         self
     }
 }
 
-impl fmt::Display for App {
+impl fmt::Display for Cmd {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let desc = if !self.description.is_empty() {
             format!("{}\n", &self.description)
@@ -81,9 +81,9 @@ impl fmt::Display for App {
     }
 }
 
-impl default::Default for App {
+impl default::Default for Cmd {
     fn default() -> Self {
-        App {
+        Cmd {
             name: String::new(),
             author: String::new(),
             description: String::new(),
@@ -93,7 +93,7 @@ impl default::Default for App {
     }
 }
 
-impl App {
+impl Cmd {
     /// parse expects a Vec<String> representing all argumets provided from
     /// std::env::Args, including the base command and attempts to parse it
     /// into a corresponding Config.

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -35,7 +35,7 @@ fn should_parse_raw_input_vec_to_config() {
     expected_config.insert("size".to_string(), Value::Integer(1024));
 
     assert_eq!(
-        Ok(expected_config),
+        expected_config,
         Cmd::new()
             .name("example")
             .description("this is a test")
@@ -56,6 +56,8 @@ fn should_parse_raw_input_vec_to_config() {
                     .value_type(ValueType::Integer)
             )
             .parse(input)
+            .unwrap()
+            .to_config()
     );
 }
 
@@ -67,7 +69,7 @@ fn should_set_default_values_on_unprovided_values() {
     expected_config.insert("size".to_string(), Value::Integer(1024));
 
     assert_eq!(
-        Ok(expected_config),
+        expected_config,
         Cmd::new()
             .name("example")
             .description("this is a test")
@@ -89,6 +91,8 @@ fn should_set_default_values_on_unprovided_values() {
                     .default_value(Value::Integer(1024))
             )
             .parse(input)
+            .unwrap()
+            .to_config()
     );
 }
 
@@ -121,7 +125,7 @@ fn should_accept_dispatch_handler() {
     expected_config.insert("version".to_string(), Value::Bool(true));
 
     assert_eq!(
-        Ok(expected_config),
+        expected_config,
         Cmd::new()
             .name("example")
             .description("this is a test")
@@ -136,5 +140,7 @@ fn should_accept_dispatch_handler() {
             )
             .handler(Box::new(|_| Ok(0)))
             .parse(input)
+            .unwrap()
+            .to_config()
     );
 }

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -113,3 +113,28 @@ fn should_ignore_invalid_flags() {
             .parse(input)
     );
 }
+
+#[test]
+fn should_accept_dispatch_handler() {
+    let input = to_string_vec!(vec!["example", "--version"]);
+    let mut expected_config = Config::new();
+    expected_config.insert("version".to_string(), Value::Bool(true));
+
+    assert_eq!(
+        Ok(expected_config),
+        Cmd::new()
+            .name("example")
+            .description("this is a test")
+            .author("John Doe <jdoe@example.com>")
+            .version("1.2.3")
+            .flag(
+                Flag::new()
+                    .name("version")
+                    .short_code("v")
+                    .action(Action::StoreTrue)
+                    .value_type(ValueType::Bool)
+            )
+            .handler(Box::new(|_| Ok(0)))
+            .parse(input)
+    );
+}

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,5 +1,5 @@
 use crate::flag::{Action, Flag, Value, ValueType};
-use crate::{App, Config};
+use crate::{Cmd, Config};
 
 mod parser;
 
@@ -13,10 +13,10 @@ macro_rules! to_string_vec {
 }
 
 #[test]
-fn should_set_app_defaults_on_new() {
+fn should_set_cmd_defaults_on_new() {
     assert_eq!(
-        App::default(),
-        App::new().name("").description("").author("").version("")
+        Cmd::default(),
+        Cmd::new().name("").description("").author("").version("")
     );
 }
 
@@ -26,7 +26,7 @@ fn should_match_expected_help_message() {
         "this is a test\nUsage: example [OPTIONS] [SUBCOMMAND]",
         format!(
             "{}",
-            App::new()
+            Cmd::new()
                 .name("example")
                 .description("this is a test")
                 .author("John Doe <jdoe@example.com>")
@@ -44,7 +44,7 @@ fn should_parse_raw_input_vec_to_config() {
 
     assert_eq!(
         Ok(expected_config),
-        App::new()
+        Cmd::new()
             .name("example")
             .description("this is a test")
             .author("John Doe <jdoe@example.com>")
@@ -76,7 +76,7 @@ fn should_set_default_values_on_unprovided_values() {
 
     assert_eq!(
         Ok(expected_config),
-        App::new()
+        Cmd::new()
             .name("example")
             .description("this is a test")
             .author("John Doe <jdoe@example.com>")
@@ -106,7 +106,7 @@ fn should_ignore_invalid_flags() {
 
     assert_eq!(
         Err("unable to parse all flags: [\"s\"]".to_string()),
-        App::new()
+        Cmd::new()
             .name("example")
             .description("this is a test")
             .author("John Doe <jdoe@example.com>")

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -13,14 +13,6 @@ macro_rules! to_string_vec {
 }
 
 #[test]
-fn should_set_cmd_defaults_on_new() {
-    assert_eq!(
-        Cmd::default(),
-        Cmd::new().name("").description("").author("").version("")
-    );
-}
-
-#[test]
 fn should_match_expected_help_message() {
     assert_eq!(
         "this is a test\nUsage: example [OPTIONS] [SUBCOMMAND]",

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -144,3 +144,28 @@ fn should_accept_dispatch_handler() {
             .to_config()
     );
 }
+
+#[test]
+fn should_dispatch() {
+    let input = to_string_vec!(vec!["example", "--version"]);
+
+    assert_eq!(
+        Ok(0),
+        Cmd::new()
+            .name("example")
+            .description("this is a test")
+            .author("John Doe <jdoe@example.com>")
+            .version("1.2.3")
+            .flag(
+                Flag::new()
+                    .name("version")
+                    .short_code("v")
+                    .action(Action::StoreTrue)
+                    .value_type(ValueType::Bool)
+            )
+            .handler(Box::new(|_| Ok(0)))
+            .parse(input)
+            .unwrap()
+            .dispatch()
+    );
+}


### PR DESCRIPTION
# Introduction
This PR includes the first set of working changes for subcommand parsing. These include:

- Switching `App` to `Cmd` to better reflect the type
- Adding a handler method for dispatching
- Adding a `CmdDispatcher` type which captures all the necessary context to run an app
- Updating the `Cmd` parse method to return a `CmdDisptacher`.

```rust
Cmd::new()
    .name("example")
    .description("this is a test")
    .author("John Doe <jdoe@example.com>")
    .version("1.2.3")
    .flag(
        Flag::new()
            .name("version")
            .short_code("v")
            .action(Action::StoreTrue)
            .value_type(ValueType::Bool)
    )
    .handler(Box::new(|_| Ok(0)))
    .parse(input)
    .unwrap()
    .to_config()
```

# Linked Issues
#5 
# Dependencies

# Test
- [x] Tested Locally
- [ ] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
