### PR TITLE
Validate Command String Matches Path

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,19 @@ mod tests;
 /// Config represents a String -> Value mapping as parsed from flags.
 pub type Config = HashMap<String, Value>;
 
+fn config_from_defaults(flags: &[Flag]) -> Config {
+    let mut cm = Config::new();
+
+    for f in flags.iter() {
+        match f.default_value {
+            Some(ref v) => cm.insert(f.name.clone(), v.clone()),
+            None => continue,
+        };
+    }
+
+    cm
+}
+
 /// Represents the result of a dispatch function call.
 pub type DispatchFnResult = Result<u32, String>;
 
@@ -154,15 +167,7 @@ impl Cmd {
     /// std::env::Args, including the base command and attempts to parse it
     /// into a corresponding Command Dispatcher.
     pub fn parse(self, input: Vec<String>) -> Result<CmdDispatcher, String> {
-        let mut cm = Config::new();
-
-        // set defaults
-        for f in self.flags.iter() {
-            match f.default_value {
-                Some(ref v) => cm.insert(f.name.clone(), v.clone()),
-                None => continue,
-            };
-        }
+        let mut cm = config_from_defaults(&self.flags);
 
         let res = match ArgumentParser::new().parse(input)? {
             MatchStatus::Match((_, res)) => Ok(res),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -144,7 +144,7 @@ impl default::Default for Cmd {
             description: String::new(),
             version: String::new(),
             flags: Vec::new(),
-            handler_func: Box::new(|_conf| Err("Unimplemented".to_string())),
+            handler_func: Box::new(|_| Err("Unimplemented".to_string())),
         }
     }
 }

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -169,3 +169,59 @@ fn should_dispatch() {
             .dispatch()
     );
 }
+
+#[test]
+fn should_only_match_expected_command() {
+    let input = to_string_vec!(vec!["notexample", "--version"]);
+
+    assert!(Cmd::new()
+        .name("example")
+        .description("this is a test")
+        .author("John Doe <jdoe@example.com>")
+        .version("1.2.3")
+        .flag(
+            Flag::new()
+                .name("version")
+                .short_code("v")
+                .action(Action::StoreTrue)
+                .value_type(ValueType::Bool)
+        )
+        .flag(
+            Flag::new()
+                .name("size")
+                .short_code("s")
+                .action(Action::ExpectSingleValue)
+                .value_type(ValueType::Integer)
+                .default_value(Value::Integer(1024))
+        )
+        .parse(input)
+        .is_err());
+}
+
+#[test]
+fn should_match_command_with_path_prefix() {
+    let input = to_string_vec!(vec!["/usr/bin/example", "--version"]);
+
+    assert!(Cmd::new()
+        .name("example")
+        .description("this is a test")
+        .author("John Doe <jdoe@example.com>")
+        .version("1.2.3")
+        .flag(
+            Flag::new()
+                .name("version")
+                .short_code("v")
+                .action(Action::StoreTrue)
+                .value_type(ValueType::Bool)
+        )
+        .flag(
+            Flag::new()
+                .name("size")
+                .short_code("s")
+                .action(Action::ExpectSingleValue)
+                .value_type(ValueType::Integer)
+                .default_value(Value::Integer(1024))
+        )
+        .parse(input)
+        .is_ok());
+}


### PR DESCRIPTION
# Introduction
This PR includes validations around the "command" string that is parsed by each command. Previously this was not validated against the expected value of the command. This PR adds this validation in preparation of the checks that will be necessary for subcommand parsing

# Linked Issues
#5 
# Dependencies

# Test
- [x] Tested Locally
- [ ] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
