### PR TITLE
Sub-Command Parser Implementation

### DIFF
--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -1,0 +1,37 @@
+extern crate scrap;
+use scrap::flag::{Action, Flag, Value, ValueType};
+use scrap::Cmd;
+use std::env;
+
+fn main() {
+    let args: Vec<String> = env::args().into_iter().collect();
+
+    let res = Cmd::new()
+        .name("basic")
+        .description("this is a test")
+        .author("John Doe <jdoe@example.com>")
+        .version("1.2.3")
+        .flag(
+            Flag::new()
+                .name("version")
+                .short_code("v")
+                .action(Action::StoreTrue)
+                .value_type(ValueType::Bool)
+                .default_value(Value::Bool(false)),
+        )
+        .handler(Box::new(|c| {
+            println!("dispatched with config: {:?}", c);
+            Ok(0)
+        }))
+        .run(args)
+        .unwrap()
+        .dispatch();
+
+    match res {
+        Ok(_) => (),
+        Err(e) => {
+            println!("{}", e);
+            std::process::exit(1)
+        }
+    }
+}

--- a/examples/subcommands.rs
+++ b/examples/subcommands.rs
@@ -1,0 +1,41 @@
+extern crate scrap;
+use scrap::flag::{Action, Flag, Value, ValueType};
+use scrap::Cmd;
+use std::env;
+
+fn main() {
+    let args: Vec<String> = env::args().into_iter().collect();
+
+    let res = Cmd::new()
+        .name("basic")
+        .description("this is a test")
+        .author("John Doe <jdoe@example.com>")
+        .version("1.2.3")
+        .flag(
+            Flag::new()
+                .name("version")
+                .short_code("v")
+                .action(Action::StoreTrue)
+                .value_type(ValueType::Bool)
+                .default_value(Value::Bool(false)),
+        )
+        .handler(Box::new(|c| {
+            println!("root dispatched with config: {:?}", c);
+            Ok(0)
+        }))
+        .subcommand(Cmd::new().name("run").handler(Box::new(|c| {
+            println!("run subcommand dispatched with config: {:?}", c);
+            Ok(0)
+        })))
+        .run(args)
+        .unwrap()
+        .dispatch();
+
+    match res {
+        Ok(_) => (),
+        Err(e) => {
+            println!("{}", e);
+            std::process::exit(1)
+        }
+    }
+}

--- a/examples/subcommands.rs
+++ b/examples/subcommands.rs
@@ -7,7 +7,7 @@ fn main() {
     let args: Vec<String> = env::args().into_iter().collect();
 
     let res = Cmd::new()
-        .name("basic")
+        .name("subcommands")
         .description("this is a test")
         .author("John Doe <jdoe@example.com>")
         .version("1.2.3")

--- a/src/flag/mod.rs
+++ b/src/flag/mod.rs
@@ -15,6 +15,22 @@ pub enum FlagOrValue {
     Value(Value),
 }
 
+impl fmt::Display for FlagOrValue {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Self::Flag(f) => {
+                let flag = if f.len() > 1 {
+                    format!("--{}", f)
+                } else {
+                    format!("-{}", f)
+                };
+                formatter.write_str(&flag)
+            }
+            Self::Value(v) => formatter.write_fmt(format_args!("{}", v)),
+        }
+    }
+}
+
 /// ValueType represents one of the values that can be assigned to a flag.
 #[derive(Debug, PartialEq, Clone, Copy)]
 pub enum ValueType {
@@ -32,6 +48,17 @@ pub enum Value {
     Bool(bool),
     Integer(u64),
     Float(f64),
+}
+
+impl fmt::Display for Value {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Self::Str(s) => formatter.write_str(s),
+            Self::Bool(b) => formatter.write_fmt(format_args!("{}", b)),
+            Self::Integer(i) => formatter.write_fmt(format_args!("{}", i)),
+            Self::Float(f) => formatter.write_fmt(format_args!("{}", f)),
+        }
+    }
 }
 
 /// Action stores the flag action, signifying the behavior of the flag.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -195,19 +195,18 @@ impl Cmd {
         let mut cm = config_from_defaults(&self.flags);
         let mut remainder: &[FlagOrValue] = &ap_res;
         loop {
-            match self.parse(remainder) {
-                Ok(MatchStatus::Match((rem, conf))) if rem.is_empty() => {
+            match self.parse(remainder)? {
+                MatchStatus::Match((rem, conf)) if rem.is_empty() => {
                     cm.extend(conf);
                     break;
                 }
-                Ok(MatchStatus::Match((rem, conf))) => {
+                MatchStatus::Match((rem, conf)) => {
                     remainder = rem;
                     cm.extend(conf);
                 }
-                Ok(MatchStatus::NoMatch(rem)) => {
+                MatchStatus::NoMatch(rem) => {
                     return Err(format!("unable to parse full arg string: {:?}", rem))
                 }
-                Err(e) => return Err(e),
             }
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,7 +42,7 @@ fn config_from_defaults(flags: &[Flag]) -> Config {
 }
 
 /// Represents the result of a dispatch function call.
-pub type DispatchFnResult = Result<u32, String>;
+pub type DispatchFnResult = Result<i32, String>;
 
 /// DispatchFn stores an invocable function to be called by the cli
 pub type DispatchFn = dyn Fn(Config) -> DispatchFnResult;
@@ -69,7 +69,7 @@ impl CmdDispatcher {
 
     /// dispatch accepts a config as an argument to be passed on to the
     /// commands contained handler method.
-    pub fn dispatch(self) -> Result<u32, String> {
+    pub fn dispatch(self) -> Result<i32, String> {
         (self.handler_func)(self.config)
     }
 }
@@ -183,8 +183,11 @@ impl CmdGroup {
                     remainder = rem;
                     cm.extend(conf);
                 }
-                MatchStatus::NoMatch(rem) => {
+                MatchStatus::NoMatch(rem) if rem.is_empty() => {
                     return Err(format!("unable to parse full arg string: {:?}", rem))
+                }
+                MatchStatus::NoMatch(rem) => {
+                    remainder = rem;
                 }
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,8 +79,8 @@ impl PartialEq for CmdDispatcher {
     }
 }
 
-/// Cmd functions as the top level wrapper for a command line tool
-/// storing information about the tool, author, version and a brief description.
+/// Cmd functions as the wrapper for a command line tool storing information
+/// about the tool, author, version and a brief description.
 pub struct Cmd {
     name: String,
     author: String,
@@ -88,6 +88,7 @@ pub struct Cmd {
     version: String,
     flags: Vec<Flag>,
     handler_func: Box<DispatchFn>,
+    subcommands: Vec<Cmd>,
 }
 
 impl Cmd {
@@ -130,6 +131,12 @@ impl Cmd {
         self.handler_func = handler;
         self
     }
+
+    /// add a subcommand.
+    pub fn command(mut self, sc: Cmd) -> Cmd {
+        self.subcommands.push(sc);
+        self
+    }
 }
 
 impl fmt::Display for Cmd {
@@ -158,6 +165,7 @@ impl default::Default for Cmd {
             version: String::new(),
             flags: Vec::new(),
             handler_func: Box::new(|_| Err("Unimplemented".to_string())),
+            subcommands: Vec::new(),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -204,7 +204,7 @@ impl Cmd {
     }
 
     /// add a subcommand, implicily converting to a CmdGroup.
-    pub fn command(self, sc: Cmd) -> CmdGroup {
+    pub fn subcommand(self, sc: Cmd) -> CmdGroup {
         let mut cg = CmdGroup::new(self);
         cg.subcommands.push(sc);
         cg

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,6 +103,48 @@ impl CmdGroup {
         }
     }
 
+    /// Set the command name.
+    pub fn name(mut self, name: &str) -> Self {
+        self.command.name = name.to_string();
+        self
+    }
+
+    /// Set the author name.
+    pub fn author(mut self, author: &str) -> Self {
+        self.command.author = author.to_string();
+        self
+    }
+
+    /// Set the short description.
+    pub fn description(mut self, desc: &str) -> Self {
+        self.command.description = desc.to_string();
+        self
+    }
+
+    /// Set the version.
+    pub fn version(mut self, vers: &str) -> Self {
+        self.command.version = vers.to_string();
+        self
+    }
+
+    /// Set a flag.
+    pub fn flag(mut self, f: Flag) -> Self {
+        self.command.flags.push(f);
+        self
+    }
+
+    /// Set a cmd handler.
+    pub fn handler(mut self, handler: Box<DispatchFn>) -> Self {
+        self.command.handler_func = handler;
+        self
+    }
+
+    /// add a subcommand to the CmdGroup
+    pub fn subcommand(mut self, sc: Cmd) -> Self {
+        self.subcommands.push(sc);
+        self
+    }
+
     pub fn flatten(self) -> Vec<Cmd> {
         let mut cv: Vec<Cmd> = vec![self.command];
         cv.extend(self.subcommands.into_iter());
@@ -168,37 +210,37 @@ impl Cmd {
     }
 
     /// Set the command name.
-    pub fn name(mut self, name: &str) -> Cmd {
+    pub fn name(mut self, name: &str) -> Self {
         self.name = name.to_string();
         self
     }
 
     /// Set the author name.
-    pub fn author(mut self, author: &str) -> Cmd {
+    pub fn author(mut self, author: &str) -> Self {
         self.author = author.to_string();
         self
     }
 
     /// Set the short description.
-    pub fn description(mut self, desc: &str) -> Cmd {
+    pub fn description(mut self, desc: &str) -> Self {
         self.description = desc.to_string();
         self
     }
 
     /// Set the version.
-    pub fn version(mut self, vers: &str) -> Cmd {
+    pub fn version(mut self, vers: &str) -> Self {
         self.version = vers.to_string();
         self
     }
 
     /// Set a flag.
-    pub fn flag(mut self, f: Flag) -> Cmd {
+    pub fn flag(mut self, f: Flag) -> Self {
         self.flags.push(f);
         self
     }
 
     /// Set a cmd handler.
-    pub fn handler(mut self, handler: Box<DispatchFn>) -> Cmd {
+    pub fn handler(mut self, handler: Box<DispatchFn>) -> Self {
         self.handler_func = handler;
         self
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,8 @@
 use crate::flag::{Flag, FlagOrValue, Value, ValueType};
 use crate::parsers::match_value_type;
 use crate::parsers::ArgumentParser;
-use parcel::join;
-use parcel::MatchStatus;
-use parcel::Parser;
-use parcel::{one_of, zero_or_more}; // parcel parser combinators
+use parcel::{join, one_of, zero_or_more}; // parcel parser combinators
+use parcel::{MatchStatus, ParseResult, Parser};
 use std::collections::HashMap;
 use std::default;
 use std::fmt;
@@ -164,10 +162,10 @@ impl default::Default for Cmd {
 }
 
 impl Cmd {
-    /// parse expects a Vec<String> representing all argumets provided from
+    /// run expects a Vec<String> representing all argumets provided from
     /// std::env::Args, including the base command and attempts to parse it
     /// into a corresponding Command Dispatcher.
-    pub fn parse(self, input: Vec<String>) -> Result<CmdDispatcher, String> {
+    pub fn run(self, input: Vec<String>) -> Result<CmdDispatcher, String> {
         let mut cm = config_from_defaults(&self.flags);
 
         let res = match ArgumentParser::new().parse(input)? {
@@ -214,5 +212,14 @@ impl Cmd {
         }
 
         Ok(CmdDispatcher::new(cm, self.handler_func))
+    }
+}
+
+impl<'a> Parser<'a, &'a [FlagOrValue], (String, Value)> for Cmd {
+    fn parse(
+        &self,
+        input: &'a [FlagOrValue],
+    ) -> ParseResult<'a, &'a [FlagOrValue], (String, Value)> {
+        Ok(MatchStatus::NoMatch(input))
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@ use std::fmt;
 use std::path::Path;
 
 pub mod flag;
-use flag::{Flag, FlagOrValue, Value, ValueType};
+use flag::{Action, Flag, FlagOrValue, Value, ValueType};
 
 mod parsers;
 use parsers::ArgumentParser;
@@ -70,6 +70,10 @@ impl CmdDispatcher {
     /// dispatch accepts a config as an argument to be passed on to the
     /// commands contained handler method.
     pub fn dispatch(self) -> Result<i32, String> {
+        if Some(&Value::Bool(true)) == self.config.get("help") {
+            println!("help string")
+        }
+
         (self.handler_func)(self.config)
     }
 }
@@ -280,7 +284,12 @@ impl default::Default for Cmd {
             author: String::new(),
             description: String::new(),
             version: String::new(),
-            flags: Vec::new(),
+            flags: vec![Flag::new()
+                .name("help")
+                .short_code("h")
+                .action(Action::StoreTrue)
+                .value_type(ValueType::Bool)
+                .default_value(Value::Bool(false))],
             handler_func: Box::new(|_| Err("Unimplemented".to_string())),
         }
     }

--- a/src/parsers/flag_parsers.rs
+++ b/src/parsers/flag_parsers.rs
@@ -10,6 +10,15 @@ pub fn match_flag<'a>(expected: Flag) -> impl Parser<'a, &'a [FlagOrValue], Flag
     }
 }
 
+pub fn match_any_flag<'a>() -> impl Parser<'a, &'a [FlagOrValue], Flag> {
+    move |input: &'a [FlagOrValue]| match input.get(0) {
+        Some(FlagOrValue::Flag(name)) => {
+            Ok(MatchStatus::Match((&input[1..], Flag::new().name(name))))
+        }
+        _ => Ok(MatchStatus::NoMatch(input)),
+    }
+}
+
 pub fn match_value_type<'a>(expected: ValueType) -> impl Parser<'a, &'a [FlagOrValue], Value> {
     move |input: &'a [FlagOrValue]| match (expected, input.get(0)) {
         (ValueType::Any, Some(FlagOrValue::Value(v))) => {

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -55,7 +55,7 @@ fn should_parse_raw_input_vec_to_config() {
                     .action(Action::ExpectSingleValue)
                     .value_type(ValueType::Integer)
             )
-            .parse(input)
+            .run(input)
             .unwrap()
             .to_config()
     );
@@ -90,7 +90,7 @@ fn should_set_default_values_on_unprovided_values() {
                     .value_type(ValueType::Integer)
                     .default_value(Value::Integer(1024))
             )
-            .parse(input)
+            .run(input)
             .unwrap()
             .to_config()
     );
@@ -114,7 +114,7 @@ fn should_ignore_invalid_flags() {
                     .action(Action::StoreTrue)
                     .value_type(ValueType::Bool)
             )
-            .parse(input)
+            .run(input)
     );
 }
 
@@ -139,7 +139,7 @@ fn should_accept_dispatch_handler() {
                     .value_type(ValueType::Bool)
             )
             .handler(Box::new(|_| Ok(0)))
-            .parse(input)
+            .run(input)
             .unwrap()
             .to_config()
     );
@@ -164,7 +164,7 @@ fn should_dispatch() {
                     .value_type(ValueType::Bool)
             )
             .handler(Box::new(|_| Ok(0)))
-            .parse(input)
+            .run(input)
             .unwrap()
             .dispatch()
     );
@@ -194,7 +194,7 @@ fn should_only_match_expected_command() {
                 .value_type(ValueType::Integer)
                 .default_value(Value::Integer(1024))
         )
-        .parse(input)
+        .run(input)
         .is_err());
 }
 
@@ -222,6 +222,6 @@ fn should_match_command_with_path_prefix() {
                 .value_type(ValueType::Integer)
                 .default_value(Value::Integer(1024))
         )
-        .parse(input)
+        .run(input)
         .is_ok());
 }

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -215,7 +215,6 @@ fn should_match_command_with_path_prefix() {
         .run(input)
         .is_ok());
 }
-#[ignore]
 #[test]
 fn should_match_subcommand() {
     let input = to_string_vec!(vec!["/usr/bin/example", "run"]);
@@ -227,7 +226,7 @@ fn should_match_subcommand() {
             .description("this is a test")
             .author("John Doe <jdoe@example.com>")
             .version("1.2.3")
-            .command(Cmd::new().name("run").handler(Box::new(|_| Ok(0))))
+            .subcommand(Cmd::new().name("run").handler(Box::new(|_| Ok(0))))
             .run(input)
             .unwrap()
             .dispatch()

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -100,22 +100,20 @@ fn should_set_default_values_on_unprovided_values() {
 fn should_ignore_invalid_flags() {
     let input = to_string_vec!(vec!["example", "--version", "-s", "1024"]);
 
-    assert_eq!(
-        Err("unable to parse all flags: [\"s\"]".to_string()),
-        Cmd::new()
-            .name("example")
-            .description("this is a test")
-            .author("John Doe <jdoe@example.com>")
-            .version("1.2.3")
-            .flag(
-                Flag::new()
-                    .name("version")
-                    .short_code("v")
-                    .action(Action::StoreTrue)
-                    .value_type(ValueType::Bool)
-            )
-            .run(input)
-    );
+    assert!(Cmd::new()
+        .name("example")
+        .description("this is a test")
+        .author("John Doe <jdoe@example.com>")
+        .version("1.2.3")
+        .flag(
+            Flag::new()
+                .name("version")
+                .short_code("v")
+                .action(Action::StoreTrue)
+                .value_type(ValueType::Bool)
+        )
+        .run(input)
+        .is_err());
 }
 
 #[test]

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -31,6 +31,7 @@ fn should_match_expected_help_message() {
 fn should_parse_raw_input_vec_to_config() {
     let input = to_string_vec!(vec!["example", "--version", "-s", "1024"]);
     let mut expected_config = Config::new();
+    expected_config.insert("help".to_string(), Value::Bool(false));
     expected_config.insert("version".to_string(), Value::Bool(true));
     expected_config.insert("size".to_string(), Value::Integer(1024));
 
@@ -65,6 +66,7 @@ fn should_parse_raw_input_vec_to_config() {
 fn should_set_default_values_on_unprovided_values() {
     let input = to_string_vec!(vec!["example", "--version"]);
     let mut expected_config = Config::new();
+    expected_config.insert("help".to_string(), Value::Bool(false));
     expected_config.insert("version".to_string(), Value::Bool(true));
     expected_config.insert("size".to_string(), Value::Integer(1024));
 
@@ -121,6 +123,7 @@ fn should_accept_dispatch_handler() {
     let input = to_string_vec!(vec!["example", "--version"]);
     let mut expected_config = Config::new();
     expected_config.insert("version".to_string(), Value::Bool(true));
+    expected_config.insert("help".to_string(), Value::Bool(false));
 
     assert_eq!(
         expected_config,

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -232,3 +232,22 @@ fn should_match_subcommand() {
             .dispatch()
     );
 }
+
+#[test]
+fn should_match_correct_subcommand_when_multiple_are_configured() {
+    let input = to_string_vec!(vec!["/usr/bin/example", "run"]);
+
+    assert_eq!(
+        Ok(1),
+        Cmd::new()
+            .name("example")
+            .description("this is a test")
+            .author("John Doe <jdoe@example.com>")
+            .version("1.2.3")
+            .subcommand(Cmd::new().name("test").handler(Box::new(|_| Ok(0))))
+            .subcommand(Cmd::new().name("run").handler(Box::new(|_| Ok(1))))
+            .run(input)
+            .unwrap()
+            .dispatch()
+    );
+}

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -169,7 +169,7 @@ fn should_dispatch() {
 }
 
 #[test]
-fn should_only_match_expected_command() {
+fn should_throw_an_error_if_command_name_does_not_match_input_value() {
     let input = to_string_vec!(vec!["notexample", "--version"]);
 
     assert!(Cmd::new()
@@ -184,16 +184,8 @@ fn should_only_match_expected_command() {
                 .action(Action::StoreTrue)
                 .value_type(ValueType::Bool)
         )
-        .flag(
-            Flag::new()
-                .name("size")
-                .short_code("s")
-                .action(Action::ExpectSingleValue)
-                .value_type(ValueType::Integer)
-                .default_value(Value::Integer(1024))
-        )
         .run(input)
-        .is_err());
+        .is_err())
 }
 
 #[test]

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -223,3 +223,21 @@ fn should_match_command_with_path_prefix() {
         .run(input)
         .is_ok());
 }
+#[ignore]
+#[test]
+fn should_match_subcommand() {
+    let input = to_string_vec!(vec!["/usr/bin/example", "run"]);
+
+    assert_eq!(
+        Ok(0),
+        Cmd::new()
+            .name("example")
+            .description("this is a test")
+            .author("John Doe <jdoe@example.com>")
+            .version("1.2.3")
+            .command(Cmd::new().name("run").handler(Box::new(|_| Ok(0))))
+            .run(input)
+            .unwrap()
+            .dispatch()
+    );
+}


### PR DESCRIPTION
# Introduction
This PR begins the process of implementing subcommand parsing of commands. This is provided via the new subcommand method, which has been added on to `Cmd`. This method implicitly converts `Cmd` to a new type, `CmdGroup` which handles grouping cmds into a tree like structure of parent and child commands.

```rust
extern crate scrap;
use scrap::flag::{Action, Flag, Value, ValueType};
use scrap::Cmd;
use std::env;

fn main() {
    let args: Vec<String> = env::args().into_iter().collect();

    let res = Cmd::new()
        .name("subcommands")
        .description("this is a test")
        .author("John Doe <jdoe@example.com>")
        .version("1.2.3")
        .flag(
            Flag::new()
                .name("version")
                .short_code("v")
                .action(Action::StoreTrue)
                .value_type(ValueType::Bool)
                .default_value(Value::Bool(false)),
        )
        .handler(Box::new(|c| {
            println!("root dispatched with config: {:?}", c);
            Ok(0)
        }))
        .subcommand(Cmd::new().name("run").handler(Box::new(|c| {
            println!("run subcommand dispatched with config: {:?}", c);
            Ok(0)
        })))
        .run(args)
        .unwrap()
        .dispatch();

    match res {
        Ok(_) => (),
        Err(e) => {
            println!("{}", e);
            std::process::exit(1)
        }
    }
}
```

# Linked Issues
#5 

# Dependencies

# Test
- [x] Tested Locally
- [ ] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
