### PR TITLE
StoreTrue/StoreFalse sets default_value to inverse

### DIFF
--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -1,5 +1,5 @@
 extern crate scrap;
-use scrap::flag::{Action, Flag, Value, ValueType};
+use scrap::flag::{Action, Flag, ValueType};
 use scrap::Cmd;
 use std::env;
 
@@ -16,8 +16,7 @@ fn main() {
                 .name("version")
                 .short_code("v")
                 .action(Action::StoreTrue)
-                .value_type(ValueType::Bool)
-                .default_value(Value::Bool(false)),
+                .value_type(ValueType::Bool),
         )
         .handler(Box::new(|c| {
             println!("dispatched with config: {:?}", c);

--- a/examples/subcommands.rs
+++ b/examples/subcommands.rs
@@ -1,5 +1,5 @@
 extern crate scrap;
-use scrap::flag::{Action, Flag, Value, ValueType};
+use scrap::flag::{Action, Flag, ValueType};
 use scrap::Cmd;
 use std::env;
 
@@ -16,8 +16,7 @@ fn main() {
                 .name("version")
                 .short_code("v")
                 .action(Action::StoreTrue)
-                .value_type(ValueType::Bool)
-                .default_value(Value::Bool(false)),
+                .value_type(ValueType::Bool),
         )
         .handler(Box::new(|c| {
             println!("root dispatched with config: {:?}", c);

--- a/src/flag/mod.rs
+++ b/src/flag/mod.rs
@@ -108,9 +108,14 @@ impl Flag {
     }
 
     /// Set the action field.
-    pub fn action(mut self, action: Action) -> Flag {
-        self.action = action;
-        self
+    pub fn action(self, action: Action) -> Flag {
+        let mut f: Flag = match action {
+            Action::StoreFalse => self.default_value(Value::Bool(true)),
+            Action::StoreTrue => self.default_value(Value::Bool(false)),
+            _ => self,
+        };
+        f.action = action;
+        f
     }
 
     /// Set the action field.

--- a/src/flag/tests/mod.rs
+++ b/src/flag/tests/mod.rs
@@ -1,11 +1,33 @@
 use crate::flag::Action;
-use crate::flag::Flag;
+use crate::flag::{Flag, Value};
 
 #[test]
 fn should_set_flag_defaults_on_new() {
     assert_eq!(
         crate::flag::Flag::default(),
         Flag::new().name("").short_code("").help_string("")
+    );
+}
+
+#[test]
+fn should_set_false_default_value_on_flag_with_storetrue_action() {
+    assert_eq!(
+        Some(Value::Bool(false)),
+        Flag::new()
+            .name("test")
+            .action(Action::StoreTrue)
+            .default_value
+    );
+}
+
+#[test]
+fn should_set_true_default_value_on_flag_with_storefalse_action() {
+    assert_eq!(
+        Some(Value::Bool(true)),
+        Flag::new()
+            .name("test")
+            .action(Action::StoreFalse)
+            .default_value
     );
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -295,8 +295,7 @@ impl default::Default for Cmd {
                 .name("help")
                 .short_code("h")
                 .action(Action::StoreTrue)
-                .value_type(ValueType::Bool)
-                .default_value(Value::Bool(false))],
+                .value_type(ValueType::Bool)],
             handler_func: Box::new(|_| Err("Unimplemented".to_string())),
         }
     }


### PR DESCRIPTION
# Introduction
This PR removes the hard requirement of defining a default_value on Action's that imply their default value in their name. Examples being the StoreTrue/StoreFalse flags, which imply that their not being set defines an inverse default value. This allows the following

```rust
Cmd::new()
    .name("basic")
    .description("this is a test")
    .author("John Doe <jdoe@example.com>")
    .version("1.2.3")
    .flag(
        Flag::new()
            .name("version")
            .short_code("v")
            .action(Action::StoreTrue)
            .value_type(ValueType::Bool)
            .default_value(Value::Bool(false)),
    )
    .handler(Box::new(|c| {
        println!("dispatched with config: {:?}", c);
        Ok(0)
    }))
    .run(args)
    .unwrap()
    .dispatch();
```

to become

```rust
Cmd::new()
    .name("basic")
    .description("this is a test")
    .author("John Doe <jdoe@example.com>")
    .version("1.2.3")
    .flag(
        Flag::new()
            .name("version")
            .short_code("v")
            .action(Action::StoreTrue)
            .value_type(ValueType::Bool),
    )
    .handler(Box::new(|c| {
        println!("dispatched with config: {:?}", c);
        Ok(0)
    }))
    .run(args)
    .unwrap()
    .dispatch();
```

# Linked Issues
resolves #17 
# Dependencies

# Test
- [x] Tested Locally
- [ ] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
