### PR TITLE
Helpstring generation

### DIFF
--- a/examples/subcommands.rs
+++ b/examples/subcommands.rs
@@ -21,10 +21,15 @@ fn main() {
             println!("root dispatched with config: {:?}", c);
             Ok(0)
         }))
-        .subcommand(Cmd::new().name("run").handler(Box::new(|c| {
-            println!("run subcommand dispatched with config: {:?}", c);
-            Ok(0)
-        })))
+        .subcommand(
+            Cmd::new()
+                .name("run")
+                .description("execute an example subcommand")
+                .handler(Box::new(|c| {
+                    println!("run subcommand dispatched with config: {:?}", c);
+                    Ok(0)
+                })),
+        )
         .run(args)
         .unwrap()
         .dispatch();

--- a/src/flag/mod.rs
+++ b/src/flag/mod.rs
@@ -139,11 +139,7 @@ impl fmt::Display for Flag {
             format_string.push_str(&format!(", -{}", &self.short_code))
         };
 
-        if !&self.help_string.is_empty() {
-            format_string.push_str(&format!(": {}", &self.help_string))
-        };
-
-        write!(f, "{}", &format_string)
+        write!(f, "{:<20}{}", &format_string, &self.help_string)
     }
 }
 

--- a/src/flag/mod.rs
+++ b/src/flag/mod.rs
@@ -77,7 +77,7 @@ pub enum Action {
 pub struct Flag {
     pub name: String,
     pub short_code: String,
-    help_string: String,
+    pub help_string: String,
     action: Action,
     pub value_type: ValueType,
     pub default_value: Option<Value>,

--- a/src/flag/tests/mod.rs
+++ b/src/flag/tests/mod.rs
@@ -34,7 +34,7 @@ fn should_set_true_default_value_on_flag_with_storefalse_action() {
 #[test]
 fn should_generate_correct_help_message_based_off_passed_arguments() {
     assert_eq!(
-        "--version, -v: print command version",
+        "--version, -v       print command version",
         format!(
             "{}",
             Flag::new()
@@ -46,7 +46,7 @@ fn should_generate_correct_help_message_based_off_passed_arguments() {
     );
 
     assert_eq!(
-        "--version: print command version",
+        "--version           print command version",
         format!(
             "{}",
             Flag::new()
@@ -57,7 +57,7 @@ fn should_generate_correct_help_message_based_off_passed_arguments() {
     );
 
     assert_eq!(
-        "--version, -v",
+        "--version, -v       ",
         format!(
             "{}",
             Flag::new()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -293,7 +293,17 @@ impl fmt::Display for Cmd {
             "".to_string()
         };
 
-        write!(f, "{}Usage:{}[OPTIONS] [SUBCOMMAND]", desc, name)
+        write!(
+            f,
+            "Usage:{}[OPTIONS] [SUBCOMMAND]\n{}\n{}",
+            name,
+            desc,
+            self.flags
+                .iter()
+                .map(|f| format!("{}", f))
+                .collect::<Vec<String>>()
+                .join("\n")
+        )
     }
 }
 

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -15,7 +15,7 @@ macro_rules! to_string_vec {
 #[test]
 fn should_match_expected_help_message() {
     assert_eq!(
-        "this is a test\n\nFlags:\n    --help, -h\t",
+        "Usage: example [OPTIONS]\nthis is a test\n\nFlags:\n    --help, -h          print help string",
         format!(
             "{}",
             Cmd::new()

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -15,7 +15,7 @@ macro_rules! to_string_vec {
 #[test]
 fn should_match_expected_help_message() {
     assert_eq!(
-        "Usage: example [OPTIONS] [SUBCOMMAND]\nthis is a test\n\n--help, -h",
+        "this is a test\n\nFlags:\n    --help, -h\t",
         format!(
             "{}",
             Cmd::new()

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -15,7 +15,7 @@ macro_rules! to_string_vec {
 #[test]
 fn should_match_expected_help_message() {
     assert_eq!(
-        "this is a test\nUsage: example [OPTIONS] [SUBCOMMAND]",
+        "Usage: example [OPTIONS] [SUBCOMMAND]\nthis is a test\n\n--help, -h",
         format!(
             "{}",
             Cmd::new()


### PR DESCRIPTION
# Introduction
This PR updates helpstring parsing to better provide output generated from the set arguments.

```
vscode@38ce31e14e93:/workspaces/scrap$ ./target/debug/examples/subcommands -h
Usage: subcommands [OPTIONS]
this is a test

Flags:
    --help, -h          print help string
    --version, -v       

Subcommands:
    run                 execute an example subcommand
```

```
vscode@38ce31e14e93:/workspaces/scrap$ ./target/debug/examples/subcommands run -h
Usage: run [OPTIONS]
execute an example subcommand

Flags:
    --help, -h          print help string
```
# Linked Issues
resolves #5 
resolves #14 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
