### PR TITLE
Bugfix/32/flags are marked as required

### DIFF
--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -21,6 +21,14 @@ fn main() {
             println!("dispatched with config: {:?}", c);
             Ok(0)
         }))
+        .flag(
+            Flag::new()
+                .name("test")
+                .short_code("t")
+                .action(Action::StoreTrue)
+                .value_type(ValueType::Bool)
+                .default_value(Value::Bool(false)),
+        )
         .run(args)
         .unwrap()
         .dispatch();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -192,6 +192,7 @@ impl CmdGroup {
         for (offset, cmd) in self.flatten().into_iter().enumerate() {
             match cmd.parse(remainder)? {
                 MatchStatus::Match((rem, conf)) if rem.is_empty() => {
+                    cm.extend(config_from_defaults(&cmd.flags)); // set defaults
                     cm.extend(conf);
                     return Ok(CmdDispatcher::new(
                         cm,

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -254,3 +254,33 @@ fn should_match_correct_subcommand_when_multiple_are_configured() {
             .dispatch()
     );
 }
+
+#[test]
+fn should_generate_default_subcommand_flag_values() {
+    let input = to_string_vec!(vec!["/usr/bin/example", "run"]);
+    let mut expected_config = Config::new();
+    expected_config.insert("help".to_string(), Value::Bool(false));
+    expected_config.insert("test".to_string(), Value::Integer(1024));
+
+    assert_eq!(
+        expected_config,
+        Cmd::new()
+            .name("example")
+            .description("this is a test")
+            .author("John Doe <jdoe@example.com>")
+            .version("1.2.3")
+            .subcommand(
+                Cmd::new().name("run").handler(Box::new(|_| Ok(0))).flag(
+                    Flag::new()
+                        .name("test")
+                        .short_code("t")
+                        .action(Action::ExpectSingleValue)
+                        .value_type(ValueType::Integer)
+                        .default_value(Value::Integer(1024))
+                )
+            )
+            .run(input)
+            .unwrap()
+            .to_config()
+    );
+}


### PR DESCRIPTION
# Introduction
This PR fixes a bug where subcommands do not have their flag defaults set.

# Linked Issues
resolves #32 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
