### PR TITLE
Bump parcel from 1.6.0 to 1.9.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scrap"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Nate Catelli <ncatelli@packetfire.org>"]
 edition = "2018"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,4 +5,4 @@ authors = ["Nate Catelli <ncatelli@packetfire.org>"]
 edition = "2018"
 
 [dependencies]
-parcel = { git = "https://github.com/ncatelli/parcel", tag = "v1.6.0" }
+parcel = { git = "https://github.com/ncatelli/parcel", tag = "v1.9.1" }


### PR DESCRIPTION
# Introduction
This PR bumps the parcel version to 1.9.1 latest along with a small patch version bump.

# Linked Issues
resolves #37
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
