### PR TITLE
Allow specifyable return types for the handler method.

### DIFF
--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -14,29 +14,34 @@ fn main() {
                 .optional()
                 .with_default(false),
         )
-        .with_flag(scrap::Flag::store_true(
-            "version",
-            "v",
-            "output the version of the command.",
-        ))
         .with_flag(
             scrap::Flag::store_true("test", "t", "a test flag.")
                 .optional()
                 .with_default(false),
         )
-        .with_handler(|((_, version), test)| println!("Version: {}\nTest: {}", version, test));
+        .with_handler(|(_, test)| {
+            if test {
+                Ok(())
+            } else {
+                Err("Test is false".to_string())
+            }
+        });
 
     let help_string = cmd.help();
-    let eval_res = cmd.evaluate(&args[..]).map(|((help, version), test)| {
-        if help {
-            println!("{}", &help_string)
-        } else {
-            cmd.dispatch(((help, version), test))
-        }
-    });
+    let eval_res = cmd
+        .evaluate(&args[..])
+        .map_err(|e| e.to_string())
+        .and_then(|(help, test)| {
+            if help {
+                println!("{}", &help_string);
+                Ok(())
+            } else {
+                cmd.dispatch((help, test))
+            }
+        });
 
     match eval_res {
-        Ok(_) => (),
-        Err(_) => println!("{}", &help_string),
+        Ok(_) => println!("Test is true"),
+        Err(e) => println!("error: {}\n\n{}", &e, &help_string),
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -215,11 +215,11 @@ where
     }
 }
 
-impl<'a, C, A, B> Dispatchable<A, B, ()> for CmdGroup<C>
+impl<'a, C, A, B, R> Dispatchable<A, B, R> for CmdGroup<C>
 where
-    C: Evaluatable<'a, A, B> + Dispatchable<A, B, ()>,
+    C: Evaluatable<'a, A, B> + Dispatchable<A, B, R>,
 {
-    fn dispatch(self, flag_values: B) {
+    fn dispatch(self, flag_values: B) -> R {
         self.commands.dispatch(flag_values)
     }
 }
@@ -520,10 +520,10 @@ impl<T, H> Cmd<T, H> {
     ///
     /// Cmd::new("test").with_handler(|_| ());
     /// ```
-    pub fn with_handler<'a, A, B, NH>(self, handler: NH) -> Cmd<T, NH>
+    pub fn with_handler<'a, A, B, NH, R>(self, handler: NH) -> Cmd<T, NH>
     where
         T: Evaluatable<'a, A, B>,
-        NH: Fn(B),
+        NH: Fn(B) -> R,
     {
         Cmd {
             name: self.name,
@@ -616,12 +616,12 @@ where
     }
 }
 
-impl<'a, T, H, A, B> Dispatchable<A, B, ()> for Cmd<T, H>
+impl<'a, T, H, A, B, R> Dispatchable<A, B, R> for Cmd<T, H>
 where
     T: Evaluatable<'a, A, B>,
-    H: Fn(B),
+    H: Fn(B) -> R,
 {
-    fn dispatch(self, flag_values: B) {
+    fn dispatch(self, flag_values: B) -> R {
         (self.handler)(flag_values)
     }
 }


### PR DESCRIPTION
# Introduction
This PR allows defining custom return types for the handler method at compile time. This is useful for methods in the dispatcher that may need to bubble up an error from internally.

# Linked Issues
resolves #41 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
