### PR TITLE
Dispatchable with helpstring trait

### DIFF
--- a/src/prelude/v1/mod.rs
+++ b/src/prelude/v1/mod.rs
@@ -4,6 +4,10 @@ pub use crate::Defaultable;
 /// Defines behaviors for types that can dispatch an evaluator to a function.
 pub use crate::Dispatchable;
 
+/// Defines behaviors for types that can dispatch an evaluator to a function
+/// with additional help documentation.
+pub use crate::DispatchableWithHelpString;
+
 /// Defines behaviors for evaluating an input to a given type.
 pub use crate::Evaluatable;
 


### PR DESCRIPTION
# Introduction
Small PR to make commands dispatchable with a provided helpstring optionally.

An example is included in:
- [dispatch_with_helpstring.rs](https://github.com/ncatelli/scrap/blob/cc947f7f76cd5b884ae6dd16eabc554c70a57921/examples/dispatch_with_helpstring.rs)

# Linked Issues
resolves #60
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
