### PR TITLE
Positional Arguments

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,6 +1,8 @@
-# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.194.3/containers/rust/.devcontainer/base.Dockerfile
+# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.217.4/containers/rust/.devcontainer/base.Dockerfile
 
-FROM mcr.microsoft.com/vscode/devcontainers/rust:0-1
+# [Choice] Debian OS version (use bullseye on local arm64/Apple Silicon): buster, bullseye
+ARG VARIANT="buster"
+FROM mcr.microsoft.com/vscode/devcontainers/rust:0-${VARIANT}
 
 # [Optional] Uncomment this section to install additional packages.
 # RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,9 +1,14 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
-// https://github.com/microsoft/vscode-dev-containers/tree/v0.194.3/containers/rust
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.217.4/containers/rust
 {
 	"name": "Rust",
 	"build": {
-		"dockerfile": "Dockerfile"
+		"dockerfile": "Dockerfile",
+		"args": {
+			// Use the VARIANT arg to pick a Debian OS version: buster, bullseye
+			// Use bullseye when on local on arm64/Apple Silicon.
+			"VARIANT": "bullseye"
+		}
 	},
 	"runArgs": [
 		"--cap-add=SYS_PTRACE",
@@ -31,6 +36,6 @@
 	// "forwardPorts": [],
 	// Use 'postCreateCommand' to run commands after the container is created.
 	// "postCreateCommand": "rustc --version",
-	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
 	"remoteUser": "vscode"
 }

--- a/README.md
+++ b/README.md
@@ -59,7 +59,6 @@ fn main() {
 
     // The `Flag` type defines helpers for generating various common flag
     // evaluators.
-    
     // Shown below, the `help` flag represents common boolean flag with default
     // a default value.
     let help = scrap::Flag::store_true("help", "h", "output help information.")
@@ -81,14 +80,14 @@ fn main() {
     );
 
     // `Cmd` defines the named command, combining metadata without our above defined command.
-    let cmd = scrap::Cmd::new("minimal")
+    let cmd = scrap::Cmd::new("basic")
         .description("A minimal example cli.")
         .author("John Doe <jdoe@example.com>")
         .version("1.2.3")
         .with_flag(help)
         .with_flag(direction)
         // Finally a handler is defined with its signature being a product of
-        //the cli's defined flags.
+        // the cli's defined flags.
         .with_handler(|(_, direction)| println!("You chose {}.", direction));
 
     // The help method generates a help command based on the output rendered
@@ -98,17 +97,16 @@ fn main() {
     // Evaluate attempts to parse the input, evaluating all commands and flags
     // into concrete types which can be passed to `dispatch`, the defined
     // handler.
-    let res = cmd
-        .evaluate(&args[..])
-        .map_err(|e| e.to_string())
-        .and_then(|(help, direction)| {
-            if help {
-                Err("output help".to_string())
-            } else {
-                cmd.dispatch((help, direction));
-                Ok(())
-            }
-        });
+    let res =
+        cmd.evaluate(&args[..])
+            .map_err(|e| e.to_string())
+            .and_then(|Value { span, value }| match value {
+                (help, direction) if !help => {
+                    cmd.dispatch(Value::new(span, (help, direction)));
+                    Ok(())
+                }
+                _ => Err("output help".to_string()),
+            });
 
     match res {
         Ok(_) => (),

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -48,13 +48,12 @@ fn main() {
     let res = cmd
         .evaluate(&args[..])
         .map_err(|e| e.to_string())
-        .and_then(|(help, direction)| {
-            if help {
-                Err("output help".to_string())
-            } else {
+        .and_then(|flag_values| match flag_values {
+            MatchStatus::Match(_, (help, direction)) if !help => {
                 cmd.dispatch((help, direction));
                 Ok(())
             }
+            _ => Err("output help".to_string()),
         });
 
     match res {

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -48,8 +48,8 @@ fn main() {
     let res = cmd
         .evaluate(&args[..])
         .map_err(|e| e.to_string())
-        .and_then(|flag_values| match flag_values {
-            MatchStatus::Match(_, (help, direction)) if !help => {
+        .and_then(|flag_values| match flag_values.unwrap() {
+            (help, direction) if !help => {
                 cmd.dispatch((help, direction));
                 Ok(())
             }

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -45,16 +45,16 @@ fn main() {
     // Evaluate attempts to parse the input, evaluating all commands and flags
     // into concrete types which can be passed to `dispatch`, the defined
     // handler.
-    let res = cmd
-        .evaluate(&args[..])
-        .map_err(|e| e.to_string())
-        .and_then(|flag_values| match flag_values.unwrap() {
-            (help, direction) if !help => {
-                cmd.dispatch((help, direction));
-                Ok(())
-            }
-            _ => Err("output help".to_string()),
-        });
+    let res =
+        cmd.evaluate(&args[..])
+            .map_err(|e| e.to_string())
+            .and_then(|Value { span, value }| match value {
+                (help, direction) if !help => {
+                    cmd.dispatch(Value::new(span, (help, direction)));
+                    Ok(())
+                }
+                _ => Err("output help".to_string()),
+            });
 
     match res {
         Ok(_) => (),

--- a/examples/dispatch_with_args.rs
+++ b/examples/dispatch_with_args.rs
@@ -36,7 +36,7 @@ fn main() {
         .with_flag(help)
         .with_flag(direction)
         // Finally a handler is defined with its signature being a product of
-        // the cli's defined flags and a placeholder for unmatched arguments
+        // the cli's defined flags and a placeholder for unmatched arguments.
         .with_args_handler(|(help_flag_set, optional_direction), args| {
             match (help_flag_set, optional_direction) {
                 (false, Some(direction)) => {

--- a/examples/dispatch_with_args.rs
+++ b/examples/dispatch_with_args.rs
@@ -40,7 +40,8 @@ fn main() {
         .with_args_handler(|(help_flag_set, optional_direction), args| {
             match (help_flag_set, optional_direction) {
                 (false, Some(direction)) => {
-                    println!("You chose {}.\nWith the args {:?}.", direction, args)
+                    let arg_values: Vec<_> = args.into_iter().map(|a| a.unwrap()).collect();
+                    println!("You chose {}.\nWith the args {:?}.", direction, arg_values)
                 }
                 _ => println!("error"),
             }

--- a/examples/dispatch_with_args.rs
+++ b/examples/dispatch_with_args.rs
@@ -1,0 +1,61 @@
+use scrap::prelude::v1::*;
+use std::env;
+
+fn main() {
+    let raw_args: Vec<String> = env::args().into_iter().collect::<Vec<String>>();
+    let args = raw_args.iter().map(|a| a.as_str()).collect::<Vec<&str>>();
+
+    // The `Flag` type defines helpers for generating various common flag
+    // evaluators.
+    // Shown below, the `help` flag represents common boolean flag with default
+    // a default value.
+    let help = scrap::Flag::store_true("help", "h", "output help information.")
+        .optional()
+        .with_default(false);
+    // `direction` provides a flag with a finite set of choices, matching a
+    // string value.
+    let direction = scrap::Flag::with_choices(
+        "direction",
+        "d",
+        "a cardinal direction.",
+        [
+            "north".to_string(),
+            "south".to_string(),
+            "east".to_string(),
+            "west".to_string(),
+        ],
+        scrap::StringValue,
+    )
+    .optional();
+
+    // `Cmd` defines the named command, combining metadata without our above defined command.
+    let cmd = scrap::Cmd::new("dispatch_with_args")
+        .description("A minimal example cli.")
+        .author("John Doe <jdoe@example.com>")
+        .version("1.2.3")
+        .with_flag(help)
+        .with_flag(direction)
+        // Finally a handler is defined with its signature being a product of
+        // the cli's defined flags and a placeholder for unparsed arguments
+        .with_args_handler(|(help_flag_set, optional_direction), args| {
+            match (help_flag_set, optional_direction) {
+                (false, Some(direction)) => {
+                    println!("You chose {}.\nWith the args {:?}.", direction, args)
+                }
+                _ => println!("error"),
+            }
+        });
+
+    // Evaluate attempts to parse the input, evaluating all commands and flags
+    // into concrete types which can be passed to `dispatch`, the defined
+    // handler.
+    let _ = cmd
+        .evaluate(&args[..])
+        .map_err(|e| e.to_string())
+        .map(|flag_values| {
+            let args = scrap::return_unused_args(&args[..], &flag_values.span);
+            (flag_values, args)
+        })
+        .map(|(flag_values, args)| cmd.dispatch_with_args(flag_values, args))
+        .map_err(|e| println!("{}", e));
+}

--- a/examples/dispatch_with_args.rs
+++ b/examples/dispatch_with_args.rs
@@ -36,7 +36,7 @@ fn main() {
         .with_flag(help)
         .with_flag(direction)
         // Finally a handler is defined with its signature being a product of
-        // the cli's defined flags and a placeholder for unparsed arguments
+        // the cli's defined flags and a placeholder for unmatched arguments
         .with_args_handler(|(help_flag_set, optional_direction), args| {
             match (help_flag_set, optional_direction) {
                 (false, Some(direction)) => {

--- a/examples/dispatch_with_args.rs
+++ b/examples/dispatch_with_args.rs
@@ -57,6 +57,6 @@ fn main() {
             let args = scrap::return_unused_args(&args[..], &flag_values.span);
             (flag_values, args)
         })
-        .map(|(flag_values, args)| cmd.dispatch_with_args(flag_values, args))
+        .map(|(flag_values, args)| cmd.dispatch_with_args(args, flag_values))
         .map_err(|e| println!("{}", e));
 }

--- a/examples/dispatch_with_helpstring.rs
+++ b/examples/dispatch_with_helpstring.rs
@@ -51,7 +51,10 @@ fn main() {
         .evaluate(&args[..])
         .map_err(|e| e.to_string())
         .and_then(|flag_values| match flag_values {
-            MatchStatus::Match(_, v) => Ok(cmd.dispatch_with_helpstring(v)),
+            MatchStatus::Match(_, v) => {
+                cmd.dispatch_with_helpstring(v);
+                Ok(())
+            }
             MatchStatus::NoMatch(_) => Err(scrap::CliError::AmbiguousCommand.to_string()),
         })
         .map_err(|e| println!("{}", e));

--- a/examples/dispatch_with_helpstring.rs
+++ b/examples/dispatch_with_helpstring.rs
@@ -50,6 +50,9 @@ fn main() {
     let _ = cmd
         .evaluate(&args[..])
         .map_err(|e| e.to_string())
-        .map(|(help, direction)| cmd.dispatch_with_helpstring((help, direction)))
+        .and_then(|flag_values| match flag_values {
+            MatchStatus::Match(_, v) => Ok(cmd.dispatch_with_helpstring(v)),
+            MatchStatus::NoMatch(_) => Err(scrap::CliError::AmbiguousCommand.to_string()),
+        })
         .map_err(|e| println!("{}", e));
 }

--- a/examples/dispatch_with_helpstring.rs
+++ b/examples/dispatch_with_helpstring.rs
@@ -50,9 +50,6 @@ fn main() {
     let _ = cmd
         .evaluate(&args[..])
         .map_err(|e| e.to_string())
-        .map(|flag_values| {
-            let inner = flag_values.unwrap();
-            cmd.dispatch_with_helpstring(inner);
-        })
+        .map(|flag_values| cmd.dispatch_with_helpstring(flag_values))
         .map_err(|e| println!("{}", e));
 }

--- a/examples/dispatch_with_helpstring.rs
+++ b/examples/dispatch_with_helpstring.rs
@@ -50,12 +50,9 @@ fn main() {
     let _ = cmd
         .evaluate(&args[..])
         .map_err(|e| e.to_string())
-        .and_then(|flag_values| match flag_values {
-            MatchStatus::Match(_, v) => {
-                cmd.dispatch_with_helpstring(v);
-                Ok(())
-            }
-            MatchStatus::NoMatch(_) => Err(scrap::CliError::AmbiguousCommand.to_string()),
+        .map(|flag_values| {
+            let inner = flag_values.unwrap();
+            cmd.dispatch_with_helpstring(inner);
         })
         .map_err(|e| println!("{}", e));
 }

--- a/examples/subcommands.rs
+++ b/examples/subcommands.rs
@@ -36,7 +36,10 @@ fn main() {
     let eval_res = cmd_group
         .evaluate(&args[..])
         .and_then(|flag_values| match flag_values {
-            MatchStatus::Match(_, v) => Ok(cmd_group.dispatch(v)),
+            MatchStatus::Match(_, v) => {
+                cmd_group.dispatch(v);
+                Ok(())
+            }
             MatchStatus::NoMatch(_) => Err(CliError::AmbiguousCommand),
         });
 

--- a/examples/subcommands.rs
+++ b/examples/subcommands.rs
@@ -35,7 +35,10 @@ fn main() {
     let help_string = cmd_group.help();
     let eval_res = cmd_group
         .evaluate(&args[..])
-        .map(|flag_values| cmd_group.dispatch(flag_values));
+        .and_then(|flag_values| match flag_values {
+            MatchStatus::Match(_, v) => Ok(cmd_group.dispatch(v)),
+            MatchStatus::NoMatch(_) => Err(CliError::AmbiguousCommand),
+        });
 
     match eval_res {
         Ok(_) => (),

--- a/examples/subcommands.rs
+++ b/examples/subcommands.rs
@@ -33,15 +33,10 @@ fn main() {
         );
 
     let help_string = cmd_group.help();
-    let eval_res = cmd_group
-        .evaluate(&args[..])
-        .and_then(|flag_values| match flag_values {
-            MatchStatus::Match(_, v) => {
-                cmd_group.dispatch(v);
-                Ok(())
-            }
-            MatchStatus::NoMatch(_) => Err(CliError::AmbiguousCommand),
-        });
+    let eval_res = cmd_group.evaluate(&args[..]).map(|flag_values| {
+        let inner = flag_values.unwrap();
+        cmd_group.dispatch(inner);
+    });
 
     match eval_res {
         Ok(_) => (),

--- a/examples/subcommands.rs
+++ b/examples/subcommands.rs
@@ -33,10 +33,9 @@ fn main() {
         );
 
     let help_string = cmd_group.help();
-    let eval_res = cmd_group.evaluate(&args[..]).map(|flag_values| {
-        let inner = flag_values.unwrap();
-        cmd_group.dispatch(inner);
-    });
+    let eval_res = cmd_group
+        .evaluate(&args[..])
+        .map(|flag_values| cmd_group.dispatch(flag_values));
 
     match eval_res {
         Ok(_) => (),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -888,6 +888,7 @@ pub trait Dispatchable<A, B, R> {
 }
 
 /// Defines behaviors for types that can dispatch an evaluator to a function.
+/// with an optional set of unmatched arguments.
 pub trait DispatchableWithArgs<A, B, R> {
     fn dispatch_with_args(self, flag_values: Value<B>, args: Vec<String>) -> R;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -310,8 +310,8 @@ impl<'a, C, A, B, R> DispatchableWithArgs<A, B, R> for CmdGroup<C>
 where
     C: Evaluatable<'a, A, B> + DispatchableWithArgs<A, B, R>,
 {
-    fn dispatch_with_args(self, flag_values: Value<B>, args: Vec<Value<String>>) -> R {
-        self.commands.dispatch_with_args(flag_values, args)
+    fn dispatch_with_args(self, args: Vec<Value<String>>, flag_values: Value<B>) -> R {
+        self.commands.dispatch_with_args(args, flag_values)
     }
 }
 
@@ -452,13 +452,13 @@ where
     C1: Evaluatable<'a, A, B> + DispatchableWithArgs<A, B, R>,
     C2: Evaluatable<'a, A, C> + DispatchableWithArgs<A, C, R>,
 {
-    fn dispatch_with_args(self, flag_values: Value<Either<B, C>>, args: Vec<Value<String>>) -> R {
+    fn dispatch_with_args(self, args: Vec<Value<String>>, flag_values: Value<Either<B, C>>) -> R {
         let span = flag_values.span;
         let values = flag_values.value;
 
         match values {
-            Either::Left(b) => self.left.dispatch_with_args(Value::new(span, b), args),
-            Either::Right(c) => self.right.dispatch_with_args(Value::new(span, c), args),
+            Either::Left(b) => self.left.dispatch_with_args(args, Value::new(span, b)),
+            Either::Right(c) => self.right.dispatch_with_args(args, Value::new(span, c)),
         }
     }
 }
@@ -859,7 +859,7 @@ where
     T: Evaluatable<'a, A, B>,
     H: Fn(B, Vec<Value<String>>) -> R,
 {
-    fn dispatch_with_args(self, flag_values: Value<B>, args: Vec<Value<String>>) -> R {
+    fn dispatch_with_args(self, args: Vec<Value<String>>, flag_values: Value<B>) -> R {
         let inner = flag_values.unwrap();
         (self.handler)(inner, args)
     }
@@ -890,7 +890,7 @@ pub trait Dispatchable<A, B, R> {
 /// Defines behaviors for types that can dispatch an evaluator to a function.
 /// with an optional set of unmatched arguments.
 pub trait DispatchableWithArgs<A, B, R> {
-    fn dispatch_with_args(self, flag_values: Value<B>, args: Vec<Value<String>>) -> R;
+    fn dispatch_with_args(self, args: Vec<Value<String>>, flag_values: Value<B>) -> R;
 }
 
 /// Defines behaviors for types that can dispatch an evaluator to a function

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -306,6 +306,15 @@ where
     }
 }
 
+impl<'a, C, A, B, R> DispatchableWithArgs<A, B, R> for CmdGroup<C>
+where
+    C: Evaluatable<'a, A, B> + DispatchableWithArgs<A, B, R>,
+{
+    fn dispatch_with_args(self, flag_values: Value<B>, args: Vec<String>) -> R {
+        self.commands.dispatch_with_args(flag_values, args)
+    }
+}
+
 impl<'a, C, B, R> DispatchableWithHelpString<B, R> for CmdGroup<C>
 where
     Self: Helpable<Output = String>,
@@ -434,6 +443,22 @@ where
         match values {
             Either::Left(b) => self.left.dispatch(Value::new(span, b)),
             Either::Right(c) => self.right.dispatch(Value::new(span, c)),
+        }
+    }
+}
+
+impl<'a, C1, C2, A, B, C, R> DispatchableWithArgs<A, Either<B, C>, R> for OneOf<C1, C2>
+where
+    C1: Evaluatable<'a, A, B> + DispatchableWithArgs<A, B, R>,
+    C2: Evaluatable<'a, A, C> + DispatchableWithArgs<A, C, R>,
+{
+    fn dispatch_with_args(self, flag_values: Value<Either<B, C>>, args: Vec<String>) -> R {
+        let span = flag_values.span;
+        let values = flag_values.value;
+
+        match values {
+            Either::Left(b) => self.left.dispatch_with_args(Value::new(span, b), args),
+            Either::Right(c) => self.right.dispatch_with_args(Value::new(span, c), args),
         }
     }
 }
@@ -679,6 +704,32 @@ impl<T, H> Cmd<T, H> {
     }
 
     /// Returns Cmd with the handler set to the provided function in the format
+    /// of (evaluator returns).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use scrap::prelude::v1::*;
+    /// use scrap::*;
+    ///
+    /// Cmd::new("test").with_handler(|_| ());
+    /// ```
+    pub fn with_args_handler<'a, A, B, NH, R>(self, handler: NH) -> Cmd<T, NH>
+    where
+        T: Evaluatable<'a, A, B>,
+        NH: Fn(B, Vec<String>) -> R,
+    {
+        Cmd {
+            name: self.name,
+            description: self.description,
+            author: self.author,
+            version: self.version,
+            flags: self.flags,
+            handler,
+        }
+    }
+
+    /// Returns Cmd with the handler set to the provided function in the format
     /// of (helpstring, evaluator returns).
     ///
     /// # Examples
@@ -803,6 +854,17 @@ where
     }
 }
 
+impl<'a, T, H, A, B, R> DispatchableWithArgs<A, B, R> for Cmd<T, H>
+where
+    T: Evaluatable<'a, A, B>,
+    H: Fn(B, Vec<String>) -> R,
+{
+    fn dispatch_with_args(self, flag_values: Value<B>, args: Vec<String>) -> R {
+        let inner = flag_values.unwrap();
+        (self.handler)(inner, args)
+    }
+}
+
 impl<'a, T, H, B, R> DispatchableWithHelpString<B, R> for Cmd<T, H>
 where
     Self: Helpable<Output = String>,
@@ -823,6 +885,11 @@ where
 /// Defines behaviors for types that can dispatch an evaluator to a function.
 pub trait Dispatchable<A, B, R> {
     fn dispatch(self, flag_values: Value<B>) -> R;
+}
+
+/// Defines behaviors for types that can dispatch an evaluator to a function.
+pub trait DispatchableWithArgs<A, B, R> {
+    fn dispatch_with_args(self, flag_values: Value<B>, args: Vec<String>) -> R;
 }
 
 /// Defines behaviors for types that can dispatch an evaluator to a function
@@ -2623,3 +2690,39 @@ impl<'a> Evaluatable<'a, &'a [&'a str], String> for FileValue {
 }
 
 impl<'a> TerminalEvaluatable<'a, &'a [&'a str], String> for FileValue {}
+
+/// Returns all unused args from an evaluated source.
+///
+/// # Example
+///
+/// ```
+/// use scrap::prelude::v1::*;
+/// use scrap::*;
+///
+/// let input = ["hello", "a", "-n", "foo", "b", "c", "1"];
+///
+/// let evaluated_res = Cmd::new("hello")
+///     .with_flag(FlagWithValue::new("name", "n", "A name.", StringValue))
+///     .evaluate(&input[..]);
+///
+/// let val_with_args = evaluated_res.map(|flags| {
+///     let args = return_unused_args(&input[..], &flags.span);
+///     (flags, args)
+/// });
+///
+/// let expected_span = Span::from_range(0..1).join(Span::from_range(2..4));
+/// let expected_args = vec!["a", "b", "c", "1"].iter().map(|v| v.to_string()).collect();
+/// assert_eq!(
+///     Ok((Value::new(expected_span, "foo".to_string()), expected_args)),
+///     val_with_args
+/// );
+/// ```
+pub fn return_unused_args<'a>(input: &'a [&'a str], matched_span: &Span) -> Vec<String> {
+    let span = &matched_span.0;
+    input
+        .iter()
+        .enumerate()
+        .filter(|(offset, _)| !span.contains(offset))
+        .map(|(_, v)| v.to_string())
+        .collect()
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -678,7 +678,7 @@ impl<T, H> Cmd<T, H> {
     }
 
     /// Returns Cmd with the handler set to the provided function in the format
-    /// of (evaluator returns).
+    /// of `Fn(evaluator return) -> R`.
     ///
     /// # Examples
     ///
@@ -704,7 +704,7 @@ impl<T, H> Cmd<T, H> {
     }
 
     /// Returns Cmd with the handler set to the provided function in the format
-    /// of (evaluator returns).
+    /// of `Fn(evaluator return, Vec<String>) -> R`.
     ///
     /// # Examples
     ///
@@ -712,7 +712,7 @@ impl<T, H> Cmd<T, H> {
     /// use scrap::prelude::v1::*;
     /// use scrap::*;
     ///
-    /// Cmd::new("test").with_handler(|_| ());
+    /// Cmd::new("test").with_args_handler(|(), _args| ());
     /// ```
     pub fn with_args_handler<'a, A, B, NH, R>(self, handler: NH) -> Cmd<T, NH>
     where
@@ -730,7 +730,7 @@ impl<T, H> Cmd<T, H> {
     }
 
     /// Returns Cmd with the handler set to the provided function in the format
-    /// of (helpstring, evaluator returns).
+    /// of `Fn(helpstring, evaluator return) -> R`.
     ///
     /// # Examples
     ///
@@ -738,7 +738,7 @@ impl<T, H> Cmd<T, H> {
     /// use scrap::prelude::v1::*;
     /// use scrap::*;
     ///
-    /// Cmd::new("test").with_helpstring_handler(|_, _| ());
+    /// Cmd::new("test").with_helpstring_handler(|_helpstring, ()| ());
     /// ```
     pub fn with_helpstring_handler<'a, A, B, NH, R>(self, handler: NH) -> Cmd<T, NH>
     where

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1362,18 +1362,55 @@ impl std::fmt::Display for FlagHelpContext {
 
 use core::ops::Range;
 
+/// Span provides tracking of matched positions in an argument array.
 #[derive(Debug, Default, PartialEq, Clone)]
 pub struct Span(Vec<usize>);
 
 impl Span {
+    pub fn new(matches: Vec<usize>) -> Self {
+        Self(matches)
+    }
+
+    /// Returns an empty span.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use scrap::prelude::v1::*;
+    /// use scrap::*;
+    ///
+    /// assert_eq!(Span::new(vec![]), Span::empty());
+    /// ```
     pub const fn empty() -> Self {
         Span(vec![])
     }
 
+    /// Generates a Span from a given range.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use scrap::prelude::v1::*;
+    /// use scrap::*;
+    ///
+    /// assert_eq!(Span::new(vec![0, 1, 2]), Span::from_range(0..3));
+    /// ```
     pub fn from_range(range: Range<usize>) -> Self {
         Self::from(range)
     }
 
+    /// Joins two spans together.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use scrap::prelude::v1::*;
+    /// use scrap::*;
+    ///
+    /// let span_1 = Span::from_range(0..2);
+    /// let span_2 = Span::from_range(2..4);
+    /// assert_eq!(Span::new(vec![0, 1, 2, 3]), span_1.join(span_2));
+    /// ```
     pub fn join(mut self, other: Span) -> Self {
         for v in other.0 {
             self.0.push(v)

--- a/src/prelude/v1/mod.rs
+++ b/src/prelude/v1/mod.rs
@@ -8,6 +8,10 @@ pub use crate::Defaultable;
 pub use crate::Dispatchable;
 
 /// Defines behaviors for types that can dispatch an evaluator to a function
+/// with passed arguments.
+pub use crate::DispatchableWithArgs;
+
+/// Defines behaviors for types that can dispatch an evaluator to a function
 /// with additional help documentation.
 pub use crate::DispatchableWithHelpString;
 

--- a/src/prelude/v1/mod.rs
+++ b/src/prelude/v1/mod.rs
@@ -1,3 +1,6 @@
+/// provides a wrapper around match statements.
+pub use crate::MatchStatus;
+
 /// Defines behaviors for traits that can default to a if not specified value.
 pub use crate::Defaultable;
 

--- a/src/prelude/v1/mod.rs
+++ b/src/prelude/v1/mod.rs
@@ -1,5 +1,5 @@
-/// provides a wrapper around match statements.
-pub use crate::MatchStatus;
+/// Provides a wrapper around spanned matching argument values.
+pub use crate::Value;
 
 /// Defines behaviors for traits that can default to a if not specified value.
 pub use crate::Defaultable;

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -21,10 +21,7 @@ fn cmd_should_dispatch_a_valid_handler() {
     assert_eq!(
         Ok(()),
         cmd.evaluate(&["test", "-l", "info"][..])
-            .map(|flag_values| {
-                let inner = flag_values.value;
-                cmd.dispatch(inner);
-            })
+            .map(|value| cmd.dispatch(value))
     );
 }
 

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -21,12 +21,9 @@ fn cmd_should_dispatch_a_valid_handler() {
     assert_eq!(
         Ok(()),
         cmd.evaluate(&["test", "-l", "info"][..])
-            .and_then(|flag_values| match flag_values {
-                MatchStatus::Match(_, v) => {
-                    cmd.dispatch(v);
-                    Ok(())
-                }
-                MatchStatus::NoMatch(_) => Err(CliError::AmbiguousCommand),
+            .map(|flag_values| {
+                let inner = flag_values.value;
+                cmd.dispatch(inner);
             })
     );
 }

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -21,7 +21,10 @@ fn cmd_should_dispatch_a_valid_handler() {
     assert_eq!(
         Ok(()),
         cmd.evaluate(&["test", "-l", "info"][..])
-            .map(|flag_values| cmd.dispatch(flag_values))
+            .and_then(|flag_values| match flag_values {
+                MatchStatus::Match(_, v) => Ok(cmd.dispatch(v)),
+                MatchStatus::NoMatch(_) => Err(CliError::AmbiguousCommand),
+            })
     );
 }
 

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -22,7 +22,10 @@ fn cmd_should_dispatch_a_valid_handler() {
         Ok(()),
         cmd.evaluate(&["test", "-l", "info"][..])
             .and_then(|flag_values| match flag_values {
-                MatchStatus::Match(_, v) => Ok(cmd.dispatch(v)),
+                MatchStatus::Match(_, v) => {
+                    cmd.dispatch(v);
+                    Ok(())
+                }
                 MatchStatus::NoMatch(_) => Err(CliError::AmbiguousCommand),
             })
     );


### PR DESCRIPTION
# Introduction
This PR introduces the ability to pull unparsed arguments from a flag via the `DispatchWithArgs` trait. This is accomplished by transforming all `Evaluatable` implementations to return a `Value` type. For now this ValueType simply contains a parameterized value and it's corresponding span data, This can be used to associate all inputs to their corresponding matches.

A example has been provided via dispatch_with_args.rs.
# Linked Issues
resolves #48 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
