### PR TITLE
Fix type constraints for DispatchWithArgs

### DIFF
--- a/examples/dispatch_with_args.rs
+++ b/examples/dispatch_with_args.rs
@@ -37,7 +37,7 @@ fn main() {
         .with_flag(direction)
         // Finally a handler is defined with its signature being a product of
         // the cli's defined flags and a placeholder for unmatched arguments.
-        .with_args_handler(|(help_flag_set, optional_direction), args| {
+        .with_args_handler(|args, (help_flag_set, optional_direction)| {
             match (help_flag_set, optional_direction) {
                 (false, Some(direction)) => {
                     let arg_values: Vec<_> = args.into_iter().map(|a| a.unwrap()).collect();
@@ -55,8 +55,8 @@ fn main() {
         .map_err(|e| e.to_string())
         .map(|flag_values| {
             let args = scrap::return_unused_args(&args[..], &flag_values.span);
-            (flag_values, args)
+            (args, flag_values)
         })
-        .map(|(flag_values, args)| cmd.dispatch_with_args(args, flag_values))
+        .map(|(args, flag_values)| cmd.dispatch_with_args(args, flag_values))
         .map_err(|e| println!("{}", e));
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -704,7 +704,7 @@ impl<T, H> Cmd<T, H> {
     }
 
     /// Returns Cmd with the handler set to the provided function in the format
-    /// of `Fn(evaluator return, Vec<String>) -> R`.
+    /// of `Fn(Vec<Value<String>>, evaluator return) -> R`.
     ///
     /// # Examples
     ///
@@ -712,12 +712,12 @@ impl<T, H> Cmd<T, H> {
     /// use scrap::prelude::v1::*;
     /// use scrap::*;
     ///
-    /// Cmd::new("test").with_args_handler(|(), _args| ());
+    /// Cmd::new("test").with_args_handler(|_args, ()| ());
     /// ```
     pub fn with_args_handler<'a, A, B, NH, R>(self, handler: NH) -> Cmd<T, NH>
     where
         T: Evaluatable<'a, A, B>,
-        NH: Fn(B, Vec<Value<String>>) -> R,
+        NH: Fn(Vec<Value<String>>, B) -> R,
     {
         Cmd {
             name: self.name,
@@ -857,11 +857,11 @@ where
 impl<'a, T, H, A, B, R> DispatchableWithArgs<A, B, R> for Cmd<T, H>
 where
     T: Evaluatable<'a, A, B>,
-    H: Fn(B, Vec<Value<String>>) -> R,
+    H: Fn(Vec<Value<String>>, B) -> R,
 {
     fn dispatch_with_args(self, args: Vec<Value<String>>, flag_values: Value<B>) -> R {
         let inner = flag_values.unwrap();
-        (self.handler)(inner, args)
+        (self.handler)(args, inner)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -310,7 +310,7 @@ impl<'a, C, A, B, R> DispatchableWithArgs<A, B, R> for CmdGroup<C>
 where
     C: Evaluatable<'a, A, B> + DispatchableWithArgs<A, B, R>,
 {
-    fn dispatch_with_args(self, args: Vec<Value<String>>, flag_values: Value<B>) -> R {
+    fn dispatch_with_args(self, args: StringArgs, flag_values: Value<B>) -> R {
         self.commands.dispatch_with_args(args, flag_values)
     }
 }
@@ -452,7 +452,7 @@ where
     C1: Evaluatable<'a, A, B> + DispatchableWithArgs<A, B, R>,
     C2: Evaluatable<'a, A, C> + DispatchableWithArgs<A, C, R>,
 {
-    fn dispatch_with_args(self, args: Vec<Value<String>>, flag_values: Value<Either<B, C>>) -> R {
+    fn dispatch_with_args(self, args: StringArgs, flag_values: Value<Either<B, C>>) -> R {
         let span = flag_values.span;
         let values = flag_values.value;
 
@@ -704,7 +704,7 @@ impl<T, H> Cmd<T, H> {
     }
 
     /// Returns Cmd with the handler set to the provided function in the format
-    /// of `Fn(Vec<Value<String>>, evaluator return) -> R`.
+    /// of `Fn(StringArgs, evaluator return) -> R`.
     ///
     /// # Examples
     ///
@@ -717,7 +717,7 @@ impl<T, H> Cmd<T, H> {
     pub fn with_args_handler<'a, A, B, NH, R>(self, handler: NH) -> Cmd<T, NH>
     where
         T: Evaluatable<'a, A, B>,
-        NH: Fn(Vec<Value<String>>, B) -> R,
+        NH: Fn(StringArgs, B) -> R,
     {
         Cmd {
             name: self.name,
@@ -857,9 +857,9 @@ where
 impl<'a, T, H, A, B, R> DispatchableWithArgs<A, B, R> for Cmd<T, H>
 where
     T: Evaluatable<'a, A, B>,
-    H: Fn(Vec<Value<String>>, B) -> R,
+    H: Fn(StringArgs, B) -> R,
 {
-    fn dispatch_with_args(self, args: Vec<Value<String>>, flag_values: Value<B>) -> R {
+    fn dispatch_with_args(self, args: StringArgs, flag_values: Value<B>) -> R {
         let inner = flag_values.unwrap();
         (self.handler)(args, inner)
     }
@@ -890,7 +890,7 @@ pub trait Dispatchable<A, B, R> {
 /// Defines behaviors for types that can dispatch an evaluator to a function.
 /// with an optional set of unmatched arguments.
 pub trait DispatchableWithArgs<A, B, R> {
-    fn dispatch_with_args(self, args: Vec<Value<String>>, flag_values: Value<B>) -> R;
+    fn dispatch_with_args(self, args: StringArgs, flag_values: Value<B>) -> R;
 }
 
 /// Defines behaviors for types that can dispatch an evaluator to a function
@@ -1359,6 +1359,9 @@ impl std::fmt::Display for FlagHelpContext {
         }
     }
 }
+
+/// Represents a vector of spanning arguments.
+pub type StringArgs = Vec<Value<String>>;
 
 use core::ops::Range;
 
@@ -2794,7 +2797,7 @@ impl<'a> TerminalEvaluatable<'a, &'a [&'a str], String> for FileValue {}
 ///     val_with_args
 /// );
 /// ```
-pub fn return_unused_args<'a>(input: &'a [&'a str], matched_span: &Span) -> Vec<Value<String>> {
+pub fn return_unused_args<'a>(input: &'a [&'a str], matched_span: &Span) -> StringArgs {
     let span = &matched_span.0;
     input
         .iter()


### PR DESCRIPTION
# Introduction
This PR rearranges a few type constraints to align with the change to add unmatched args before matched flags in #64.

# Linked Issues
#48 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
