### PR TITLE
Implement DispatchWithHelpStringAndArgs trait

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ A minimal command-line utility framework built with zero external dependencies. 
 			- [Dispatchable](#dispatchable)
             - [DispatchableWithArgs](#dispatchablewithargs)
             - [DispatchableWithHelpString](#dispatchablewithhelpstring)
+            - [DispatchableWithHelpStringAndArgs](#dispatchablewithhelpstringandargs)
 			- [Putting it all together](#putting-it-all-together)
 	- [Testing](#testing)
 		- [Locally](#locally)
@@ -272,7 +273,32 @@ where
 }
 ```
 
-If given the above `Evaluatable` A cli's implemented dispatchable would take an `Fn(String, (B, C))` and yield whatever return type is defined for the closure.
+
+#### DispatchableWithHelpStringAndArgs
+DispatchableWithHelpStringAndArgs provides a method, `dispatch_with_help_string_and_args` and `dispatch_with_supplied_helpstring_and_args` whose signature is equivalent to the output of all Flag `Evaluatable`s and a preceeding String, along with all unparsed arguments.
+
+To illustrate this behavior, I will reference the above `Join`.
+
+```rust
+impl<'a, E1, E2, A, B, C> Evaluatable<'a, A, (B, C)> for Join<E1, E2>
+where
+    A: Copy + std::borrow::Borrow<A> + 'a,
+    E1: Evaluatable<'a, A, B>,
+    E2: Evaluatable<'a, A, C>,
+{
+    fn evaluate(&self, input: A) -> EvaluateResult<'a, (B, C)> {
+        self.evaluator1
+            .evaluate(input)
+            .map_err(|e| e)
+            .and_then(|e1_res| match self.evaluator2.evaluate(input) {
+                Ok(e2_res) => Ok((e1_res, e2_res)),
+                Err(e) => Err(e),
+            })
+    }
+}
+```
+
+If given the above `Evaluatable` A cli's implemented dispatchable would take an `Fn(String, Vec<Value<String>>, (B, C))` and yield whatever return type is defined for the closure.
 
 #### Putting it all together
 To illustrate how easy it is to write custom `Evaluator` implementations, I will show an example of a `WithOpen` evaluator below, which takes an evaluator that yields a type marked `Openable` and attempts to open the resulting value as a file. 

--- a/examples/dispatch_with_helpstring_and_args.rs
+++ b/examples/dispatch_with_helpstring_and_args.rs
@@ -36,7 +36,7 @@ fn main() {
         .with_flag(help)
         .with_flag(direction)
         // Finally a handler is defined with its signature being a product of
-        // the cli's helpstring and defined flags.
+        // the cli's helpstring, defined flags and all unparsed arguments.
         .with_helpstring_and_args_handler(
             |help_string, args: scrap::StringArgs, (help_flag_set, optional_direction)| match (
                 help_flag_set,

--- a/examples/dispatch_with_helpstring_and_args.rs
+++ b/examples/dispatch_with_helpstring_and_args.rs
@@ -1,0 +1,65 @@
+use scrap::prelude::v1::*;
+use std::env;
+
+fn main() {
+    let raw_args: Vec<String> = env::args().into_iter().collect::<Vec<String>>();
+    let args = raw_args.iter().map(|a| a.as_str()).collect::<Vec<&str>>();
+
+    // The `Flag` type defines helpers for generating various common flag
+    // evaluators.
+    // Shown below, the `help` flag represents common boolean flag with default
+    // a default value.
+    let help = scrap::Flag::store_true("help", "h", "output help information.")
+        .optional()
+        .with_default(false);
+    // `direction` provides a flag with a finite set of choices, matching a
+    // string value.
+    let direction = scrap::Flag::with_choices(
+        "direction",
+        "d",
+        "a cardinal direction.",
+        [
+            "north".to_string(),
+            "south".to_string(),
+            "east".to_string(),
+            "west".to_string(),
+        ],
+        scrap::StringValue,
+    )
+    .optional();
+
+    // `Cmd` defines the named command, combining metadata without our above defined command.
+    let cmd = scrap::Cmd::new("dispatch_with_helpstring_and_args")
+        .description("A minimal example cli.")
+        .author("John Doe <jdoe@example.com>")
+        .version("1.2.3")
+        .with_flag(help)
+        .with_flag(direction)
+        // Finally a handler is defined with its signature being a product of
+        // the cli's helpstring and defined flags.
+        .with_helpstring_and_args_handler(
+            |help_string, args: scrap::StringArgs, (help_flag_set, optional_direction)| match (
+                help_flag_set,
+                optional_direction,
+            ) {
+                (false, Some(direction)) => {
+                    let arg_values = args.into_iter().map(|arg| arg.unwrap()).collect::<Vec<_>>();
+                    println!("You chose {}.\nWith args: {:?}.", direction, arg_values)
+                }
+                _ => println!("{}", help_string),
+            },
+        );
+
+    // Evaluate attempts to parse the input, evaluating all commands and flags
+    // into concrete types which can be passed to `dispatch`, the defined
+    // handler.
+    let _ = cmd
+        .evaluate(&args[..])
+        .map_err(|e| e.to_string())
+        .map(|flag_values| {
+            let args = scrap::return_unused_args(&args[..], &flag_values.span);
+            (args, flag_values)
+        })
+        .map(|(args, flag_values)| cmd.dispatch_with_helpstring_and_args(args, flag_values))
+        .map_err(|e| println!("{}", e));
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -829,6 +829,32 @@ impl<T, H> Cmd<T, H> {
             handler,
         }
     }
+
+    /// Returns Cmd with the handler set to the provided function in the format
+    /// of `Fn(helpstring, StringArgs, evaluator return) -> R`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use scrap::prelude::v1::*;
+    /// use scrap::*;
+    ///
+    /// Cmd::new("test").with_helpstring_and_args_handler(|_helpstring, _args, ()| ());
+    /// ```
+    pub fn with_helpstring_and_args_handler<'a, A, B, NH, R>(self, handler: NH) -> Cmd<T, NH>
+    where
+        T: Evaluatable<'a, A, B>,
+        NH: Fn(String, StringArgs, B) -> R,
+    {
+        Cmd {
+            name: self.name,
+            description: self.description,
+            author: self.author,
+            version: self.version,
+            flags: self.flags,
+            handler,
+        }
+    }
 }
 
 impl<T, H> Cmd<T, H>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -315,10 +315,10 @@ where
     }
 }
 
-impl<'a, C, B, R> DispatchableWithHelpString<B, R> for CmdGroup<C>
+impl<'a, A, C, B, R> DispatchableWithHelpString<A, B, R> for CmdGroup<C>
 where
     Self: Helpable<Output = String>,
-    C: DispatchableWithHelpString<B, R>,
+    C: DispatchableWithHelpString<A, B, R>,
 {
     fn dispatch_with_helpstring(self, flag_values: Value<B>) -> R {
         let help_string = self.help();
@@ -463,11 +463,11 @@ where
     }
 }
 
-impl<'a, C1, C2, B, C, R> DispatchableWithHelpString<Either<B, C>, R> for OneOf<C1, C2>
+impl<'a, A, C1, C2, B, C, R> DispatchableWithHelpString<A, Either<B, C>, R> for OneOf<C1, C2>
 where
     Self: Helpable<Output = String>,
-    C1: DispatchableWithHelpString<B, R>,
-    C2: DispatchableWithHelpString<C, R>,
+    C1: DispatchableWithHelpString<A, B, R>,
+    C2: DispatchableWithHelpString<A, C, R>,
 {
     fn dispatch_with_helpstring(self, flag_values: Value<Either<B, C>>) -> R {
         let help_string = self.help();
@@ -865,9 +865,10 @@ where
     }
 }
 
-impl<'a, T, H, B, R> DispatchableWithHelpString<B, R> for Cmd<T, H>
+impl<'a, A, T, H, B, R> DispatchableWithHelpString<A, B, R> for Cmd<T, H>
 where
     Self: Helpable<Output = String>,
+    T: Evaluatable<'a, A, B>,
     H: Fn(String, B) -> R,
 {
     fn dispatch_with_helpstring(self, flag_values: Value<B>) -> R {
@@ -895,9 +896,19 @@ pub trait DispatchableWithArgs<A, B, R> {
 
 /// Defines behaviors for types that can dispatch an evaluator to a function
 /// with additional help documentation.
-pub trait DispatchableWithHelpString<B, R> {
+pub trait DispatchableWithHelpString<A, B, R> {
     fn dispatch_with_helpstring(self, flag_values: Value<B>) -> R;
     fn dispatch_with_supplied_helpstring(self, help_string: String, flag_values: Value<B>) -> R;
+}
+
+pub trait DispatchableWithArgsAndHelpString<A, B, R> {
+    fn dispatch_with_args_and_helpstring(self, args: StringArgs, flag_values: Value<B>) -> R;
+    fn dispatch_with_args_and_supplied_helpstring(
+        self,
+        args: StringArgs,
+        help_string: String,
+        flag_values: Value<B>,
+    ) -> R;
 }
 
 /// Much like Helpable, ShortHelpable is for defining the functionality to

--- a/src/prelude/v1/mod.rs
+++ b/src/prelude/v1/mod.rs
@@ -15,6 +15,10 @@ pub use crate::DispatchableWithArgs;
 /// with additional help documentation.
 pub use crate::DispatchableWithHelpString;
 
+/// Defines behaviors for types that can dispatch an evaluator to a function
+/// with both a generated helpstring and all unparsed args.
+pub use crate::DispatchableWithHelpStringAndArgs;
+
 /// Defines behaviors for evaluating an input to a given type.
 pub use crate::Evaluatable;
 


### PR DESCRIPTION
# Introduction
This PR introduces one final trait, `DispatchWithHelpStringAndArgs` to cover the joined usecase of having the need to pass both args and a helpstring.

# Linked Issues
resolves #66 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
