### PR TITLE
Add period to FileArument documentation.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2851,7 +2851,7 @@ pub struct FileValue {
 impl IsFlag for FileValue {}
 
 impl FileValue {
-    /// Instantiates a new instance of FileArgument
+    /// Instantiates a new instance of FileArgument.
     ///
     /// # Example
     ///


### PR DESCRIPTION
# Introduction
Follow up to #70 to tack a period on to the end of the docstring.
# Linked Issues

# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
